### PR TITLE
Change the value of hbase.regionserver.thrift.framed for security?

### DIFF
--- a/hbase/config.yaml
+++ b/hbase/config.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: hbase-config
 data:
+
+  HBASE-SITE.XML_hbase.regionserver.thrift.framed: "false"
+  HBASE-SITE.XML_hbase.regionserver.thrift.compact: "true"
   HBASE-SITE.XML_hbase.rootdir: hdfs://hdfs-namenode-0.hdfs-namenode:9820/hbase
   HBASE-SITE.XML_hbase.cluster.distributed: "true"
   HBASE-SITE.XML_hbase.zookeeper.quorum: zookeeper-0.zookeeper

--- a/test/hbase-config-configmap.yaml
+++ b/test/hbase-config-configmap.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: hbase-config
 data:
+  HBASE-SITE.XML_hbase.regionserver.thrift.framed: "false"
+  HBASE-SITE.XML_hbase.regionserver.thrift.compact: "true"
   HBASE-SITE.XML_hbase.rootdir: hdfs://hdfs-namenode-0.hdfs-namenode:9820/hbase
   HBASE-SITE.XML_hbase.cluster.distributed: "true"
   HBASE-SITE.XML_hbase.zookeeper.quorum: zookeeper-0.zookeeper


### PR DESCRIPTION
Thanks for providing the container! I am doing a research aiming at finding issues in configuration files. After pulling your image we notice that `hbase.regionserver.thrift.framed` is set to `False` in the configuration file.

However, the HBase [official document](https://hbase.apache.org/book.html#hbase.regionserver.thrift.framed) and Cloudera [troubleshooting page](https://www.cloudera.com/documentation/enterprise/latest/topics/cdh_ig_hbase_troubleshooting.html) recommends to set `hbase.regionserver.thrift.framed` and `hbase.regionserver.thrift.compact` to `True` for security:

* This is the recommended transport for thrift servers and requires a similar setting on the client side. Changing this to false will select the default transport, vulnerable to DoS when malformed requests are issued due to THRIFT-601.

* To prevent the possibility of crashes due to buffer overruns, use the framed and compact transport protocols by setting hbase.regionserver.thrift.framed and hbase.regionserver.thrift.compact to true in hbase-site.xml.

Maybe it's better to enable these two parameters? Thank you!